### PR TITLE
Added generators

### DIFF
--- a/src/Sphream.php
+++ b/src/Sphream.php
@@ -51,4 +51,20 @@ class Sphream
 			}
 		}
 	}
+
+	public function count(): int
+	{
+		if (is_array($this->iterable)) {
+			return sizeof($this->iterable);
+		}
+		return iterator_count($this->iterable);
+	}
+
+	public function toArray(): array
+	{
+		if (is_array($this->iterable)) {
+			return $this->iterable;
+		}
+		return iterator_to_array($this->iterable);
+	}
 }

--- a/src/Sphream.php
+++ b/src/Sphream.php
@@ -17,6 +17,19 @@ class Sphream
 		return new self($iterable);
 	}
 
+	public static function range(int $from, int $to): Sphream
+	{
+		if ($from > $to) {
+			throw new \InvalidArgumentException("First argument must be smaller than second argument");
+		}
+		$generator = function () use ($from, $to) {
+			for ($i = $from; $i < $to; $i++) {
+				yield $i;
+			}
+		};
+		return self::of($generator());
+	}
+
 	public function first()
 	{
 		if (is_array($this->iterable)) {

--- a/src/Sphream.php
+++ b/src/Sphream.php
@@ -43,6 +43,16 @@ class Sphream
 		return new self($generator());
 	}
 
+	public static function generate(callable $supplier): Sphream
+	{
+		$generator = function () use ($supplier) {
+			while (true) {
+				yield $supplier();
+			}
+		};
+		return new self($generator());
+	}
+
 	public function first()
 	{
 		if (is_array($this->iterable)) {

--- a/src/Sphream.php
+++ b/src/Sphream.php
@@ -30,6 +30,19 @@ class Sphream
 		return self::of($generator());
 	}
 
+	public static function repeat($toRepeat, int $repeatAmount): Sphream
+	{
+		if ($repeatAmount < 0) {
+			throw new \InvalidArgumentException("Amount to repeat cannot be negative");
+		}
+		$generator = function () use ($toRepeat, $repeatAmount) {
+			for ($i = 0; $i < $repeatAmount; $i++) {
+				yield $toRepeat;
+			}
+		};
+		return new self($generator());
+	}
+
 	public function first()
 	{
 		if (is_array($this->iterable)) {

--- a/test/SphreamTest.php
+++ b/test/SphreamTest.php
@@ -195,4 +195,16 @@ final class SphreamTest extends \PHPUnit\Framework\TestCase
 		$this->expectException(InvalidArgumentException::class);
 		Sphream::range(5, 4);
 	}
+
+	public function testIfRepeatThrowsInvalidArgumentIfSecondArgumentIsNegative()
+	{
+		$this->expectException(InvalidArgumentException::class);
+		Sphream::repeat('foo', -1);
+	}
+
+	public function testIfRepeatReturnsSphreamWithFirstArgumentRepeated()
+	{
+		$sphream = Sphream::repeat('foo', 3);
+		$this->assertEquals(['foo', 'foo', 'foo'], $sphream->toArray());
+	}
 }

--- a/test/SphreamTest.php
+++ b/test/SphreamTest.php
@@ -117,4 +117,65 @@ final class SphreamTest extends \PHPUnit\Framework\TestCase
 		$this->expectException(EmptySphream::class);
 		$sphream->last();
 	}
+
+	public function testIfCountReturnsZeroWithSphreamCreatedFromEmptyArray()
+	{
+		$sphream = Sphream::of([]);
+		$this->assertEquals(0, $sphream->count());
+	}
+
+	public function testIfCountReturnsTheSizeOfArrayUsedToCreateSphream()
+	{
+		$sphream = Sphream::of([5, 876, 2]);
+		$this->assertEquals(3, $sphream->count());
+	}
+
+	public function testIfCountReturnsZeroWithSphreamCreatedFromEmptyGenerator()
+	{
+		$generator = function () {
+			yield from [];
+		};
+		$sphream = Sphream::of($generator());
+		$this->assertEquals(0, $sphream->count());
+	}
+
+	public function testIfCountReturnsSizeOfGeneratorUsedToCreateSphream()
+	{
+		$generator = function () {
+			yield from [54, 323, 235];
+		};
+		$sphream = Sphream::of($generator());
+		$this->assertEquals(3, $sphream->count());
+	}
+
+	public function testIfToArrayReturnsEmptyArrayFromSphreamCreatedFormEmptyArray()
+	{
+		$sphream = Sphream::of([]);
+		$this->assertEquals([], $sphream->toArray());
+	}
+
+	public function testIfToArrayReturnsEmptyArrayFromSphreamCreatedFromEmptyGenerator()
+	{
+		$generator = function () {
+			yield from [];
+		};
+		$sphream = Sphream::of($generator());
+		$this->assertEquals([], $sphream->toArray());
+	}
+
+	public function testIfToArrayReturnsArrayUsedToCreateSphream()
+	{
+		$sphream = Sphream::of([432, 234, 2]);
+		$this->assertEquals([432, 234, 2], $sphream->toArray());
+	}
+
+	public function testIfToArrayReturnsElementsFormGeneratorUsedToCreateSphream()
+	{
+		$generator = function () {
+			yield from [432, 234, 2];
+		};
+		$sphream = Sphream::of($generator());
+		$this->assertEquals([432, 234, 2], $sphream->toArray());
+	}
+
 }

--- a/test/SphreamTest.php
+++ b/test/SphreamTest.php
@@ -207,4 +207,13 @@ final class SphreamTest extends \PHPUnit\Framework\TestCase
 		$sphream = Sphream::repeat('foo', 3);
 		$this->assertEquals(['foo', 'foo', 'foo'], $sphream->toArray());
 	}
+
+	public function testIfGenerateReturnsSphream()
+	{
+		$supplier = function () {
+			return 4;
+		};
+		$sphream = Sphream::generate($supplier);
+		$this->assertInstanceOf(Sphream::class, $sphream);
+	}
 }

--- a/test/SphreamTest.php
+++ b/test/SphreamTest.php
@@ -178,4 +178,21 @@ final class SphreamTest extends \PHPUnit\Framework\TestCase
 		$this->assertEquals([432, 234, 2], $sphream->toArray());
 	}
 
+	public function testIfRangeReturnsEmptySphreamWithInputsEqual()
+	{
+		$sphream = Sphream::range(4, 4);
+		$this->assertEquals(0, $sphream->count());
+	}
+
+	public function testIfRangeReturnsSphreamWithIntegers()
+	{
+		$sphream = Sphream::range(3, 9);
+		$this->assertEquals([3, 4, 5, 6, 7, 8], $sphream->toArray());
+	}
+
+	public function testIfRangeThrowsInvalidExceptionIfFirstArgumentIsLarger()
+	{
+		$this->expectException(InvalidArgumentException::class);
+		Sphream::range(5, 4);
+	}
 }


### PR DESCRIPTION
Added the methods, `range`, `repeat` and `generate` as well as the methods `count` and `toArray`.

`range` is to create a `Sphream` of all integers between to two values.
`repeat` is to create a `Sphream` of a value repeated `n` times.
`generate` is to generate an infinite `Sphream` from a supplier.