### PR TITLE
Use the very dangerous eval to make the Sphreams faster

### DIFF
--- a/src/Drop.php
+++ b/src/Drop.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Sphream;
+
+class Drop extends Method
+{
+	private $amount;
+	private $uniqueId;
+
+	public function __construct($amount, $uniqueId)
+	{
+		$this->amount = $amount;
+		$this->uniqueId = $uniqueId;
+	}
+
+	public function beforeLoop()
+	{
+		return "\${$this->uniqueId}_i = 0;";
+	}
+
+	public function reduce($body)
+	{
+		return "if (\${$this->uniqueId}_i >= {$this->amount}) { $body } \${$this->uniqueId}_i++;";
+	}
+}

--- a/src/DropWhile.php
+++ b/src/DropWhile.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Sphream;
+
+class DropWhile extends Method
+{
+	private $pointer;
+	private $uniqueId;
+
+	public function __construct($pointer, $uniqueId)
+	{
+		$this->pointer = $pointer;
+		$this->uniqueId = $uniqueId;
+	}
+
+	public function beforeLoop()
+	{
+		return "\${$this->uniqueId} = true;";
+	}
+
+	public function reduce($body)
+	{
+		return "if (\${$this->uniqueId} && !({$this->pointer})(\$item)) { \${$this->uniqueId} = false; } if (!\${$this->uniqueId}) { $body }";
+	}
+}

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Sphream;
+
+class Filter extends Method
+{
+	private $pointer;
+
+	public function __construct($pointer)
+	{
+		$this->pointer = $pointer;
+	}
+
+	public function reduce($body)
+	{
+		return "if (({$this->pointer})(\$item)) { {$body} }";
+	}
+}

--- a/src/First.php
+++ b/src/First.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Sphream;
+
+class First extends Method
+{
+	private $uniqueId;
+
+	public function __construct($uniqueId)
+	{
+		$this->uniqueId = $uniqueId;
+	}
+
+	public function beforeLoop()
+	{
+		return "\${$this->uniqueId} = false;";
+	}
+
+	public function reduce($body)
+	{
+		return "$body \${$this->uniqueId} = true; break;";
+	}
+
+	public function afterLoop()
+	{
+		return "if (!\${$this->uniqueId}) { throw new Sphream\EmptySphream(); }";
+	}
+}

--- a/src/IsEmpty.php
+++ b/src/IsEmpty.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Sphream;
+
+class IsEmpty extends Method
+{
+	public function reduce($body)
+	{
+		return "{$body} break;";
+	}
+}

--- a/src/Last.php
+++ b/src/Last.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Sphream;
+
+class Last extends Method
+{
+	private $uniqueId;
+
+	public function __construct($uniqueId)
+	{
+		$this->uniqueId = $uniqueId;
+	}
+
+	public function beforeLoop()
+	{
+		return "\${$this->uniqueId} = false;";
+	}
+
+	public function reduce($body)
+	{
+		return "$body \${$this->uniqueId} = true;";
+	}
+
+	public function afterLoop()
+	{
+		return "if (!\${$this->uniqueId}) { throw new Sphream\EmptySphream(); }";
+	}
+}

--- a/src/Map.php
+++ b/src/Map.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Sphream;
+
+class Map extends Method
+{
+	private $pointer;
+
+	public function __construct($pointer)
+	{
+		$this->pointer = $pointer;
+	}
+
+	public function reduce($body)
+	{
+		return "\$item = ({$this->pointer})(\$item); {$body}";
+	}
+}

--- a/src/Method.php
+++ b/src/Method.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Sphream;
+
+abstract class Method
+{
+	public function beforeLoop()
+	{
+		return "";
+	}
+
+	public function afterLoop()
+	{
+		return "";
+	}
+
+	public abstract function reduce($body);
+}

--- a/src/Take.php
+++ b/src/Take.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Sphream;
+
+class Take extends Method
+{
+	private $amount;
+	private $uniqueId;
+
+	public function __construct($amount, $uniqueId)
+	{
+		$this->amount = $amount;
+		$this->uniqueId = $uniqueId;
+	}
+
+	public function beforeLoop()
+	{
+		return "\${$this->uniqueId}_i = 0;";
+	}
+
+	public function reduce($body)
+	{
+		return "if (\${$this->uniqueId}_i < {$this->amount}) { \${$this->uniqueId}_i++; $body } else { break; }";
+	}
+}

--- a/src/TakeWhile.php
+++ b/src/TakeWhile.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Sphream;
+
+class TakeWhile extends Method
+{
+	private $pointer;
+	private $uniqueId;
+
+	public function __construct($pointer, $uniqueId)
+	{
+		$this->pointer = $pointer;
+		$this->uniqueId = $uniqueId;
+	}
+
+	public function beforeLoop()
+	{
+		return "\${$this->uniqueId} = true;";
+	}
+
+	public function reduce($body)
+	{
+		return "if (\${$this->uniqueId} && !({$this->pointer})(\$item)) { \${$this->uniqueId} = false; } if (\${$this->uniqueId}) { $body }";
+	}
+}


### PR DESCRIPTION
Use eval to compose all the different functions to an expression which gets executed once. In this way, less functions are being called and thus speeding up the Sphream.